### PR TITLE
GL-3: Run a simple test pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+basic:
+	@make -f Makefile.basic
+
+basic_clean:
+	@make -f Makefile.basic clean
+
+.PHONY: basic basic_clean

--- a/Makefile.basic
+++ b/Makefile.basic
@@ -1,0 +1,17 @@
+CC = gcc
+CFLAGS = $(shell pkg-config --cflags gstreamer-1.0 gstreamer-video-1.0)
+LDFLAGS = $(shell pkg-config --libs gstreamer-1.0 gstreamer-video-1.0)
+SRC_DIR = basic
+SRC = $(SRC_DIR)/basic_video_test.c
+OUT_DIR = build
+OUT = $(OUT_DIR)/basic_video_test
+
+all: $(OUT)
+
+$(OUT): $(SRC)
+	@echo "Compiling $< to $@"
+	@mkdir -p $(OUT_DIR)
+	@$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	@rm -rf $(OUT_DIR)

--- a/basic/basic_video_test.c
+++ b/basic/basic_video_test.c
@@ -1,0 +1,78 @@
+#include <gst/gst.h>
+
+int main(int argc, char *argv[]) {
+    GstElement *pipeline, *source, *sink;
+    GstBus *bus;
+    GstMessage *msg;
+    GstStateChangeReturn ret;
+
+    /* Initialize GStreamer */
+    gst_init(&argc, &argv);
+
+    /* Create pipeline elements */
+    source = gst_element_factory_make("videotestsrc", "source");
+    sink = gst_element_factory_make("autovideosink", "sink");
+
+    /* Create the pipeline */
+    pipeline = gst_pipeline_new("test-pipeline");
+
+    if (!pipeline || !source || !sink) {
+        g_printerr("Not all elements could be created.\n");
+        return -1;
+    }
+
+    /* Build the pipeline */
+    gst_bin_add_many(GST_BIN(pipeline), source, sink, NULL);
+    if (gst_element_link(source, sink) != TRUE) {
+        g_printerr("Elements could not be linked.\n");
+        gst_object_unref(pipeline);
+        return -1;
+    }
+
+    /* Set the source properties */
+    g_object_set(source, "pattern", 25, NULL); // 25 is the pattern type for a "smpte" test pattern
+
+    /* Start playing */
+    ret = gst_element_set_state(pipeline, GST_STATE_PLAYING);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        g_printerr("Unable to set the pipeline to the playing state.\n");
+        gst_object_unref(pipeline);
+        return -1;
+    }
+
+    /* Wait until error or EOS */
+    bus = gst_element_get_bus(pipeline);
+    msg = gst_bus_timed_pop_filtered(bus, GST_CLOCK_TIME_NONE,
+                                     GST_MESSAGE_ERROR | GST_MESSAGE_EOS);
+
+    /* Parse message */
+    if (msg != NULL) {
+        GError *err;
+        gchar *debug_info;
+
+        switch (GST_MESSAGE_TYPE(msg)) {
+        case GST_MESSAGE_ERROR:
+            gst_message_parse_error(msg, &err, &debug_info);
+            g_printerr("Error received from element %s: %s\n",
+                       GST_OBJECT_NAME(msg->src), err->message);
+            g_printerr("Debugging information: %s\n",
+                       debug_info ? debug_info : "none");
+            g_clear_error(&err);
+            g_free(debug_info);
+            break;
+        case GST_MESSAGE_EOS:
+            g_print("End-Of-Stream reached.\n");
+            break;
+        default:
+            g_printerr("Unexpected message received.\n");
+            break;
+        }
+        gst_message_unref(msg);
+    }
+
+    /* Free resources */
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    return 0;
+}


### PR DESCRIPTION
[Problem]
This commit introduces a basic test pipeline for video processing, which is essential for validating the functionality of the video processing module.

[Solution]
- Added a `Makefile` to manage the build process.
- Created a `Makefile.basic` for basic build configurations.
- Implemented a simple video test in `basic/basic_video_test.c`.

[Test]
This commit includes a basic test that can be run to ensure the video processing module is functioning correctly. The test can be executed using the provided Makefile.